### PR TITLE
Adding support for longer strings for secrets

### DIFF
--- a/secrets.sh
+++ b/secrets.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 secretsfile="$1"
 instance="$2"
 
@@ -6,7 +8,7 @@ get-secret () {
 }
 
 encrypt-secret () {
-    get-secret "$1" | base64
+    get-secret "$1" | base64 -w 0
 }
 
 sed -i 's/JICOFO_COMPONENT_SECRET: .*/JICOFO_COMPONENT_SECRET: '$(encrypt-secret "JICOFO_COMPONENT_SECRET")'/g' base/jitsi/jitsi-secret.yaml


### PR DESCRIPTION
`base64` wraps lines by default and `sed` fail if length is > 76
disabling wrap for string replacement [1]

This fix handles longer strings for variables like Stun/TURN servers etc.

[1] https://linux.die.net/man/1/base64