### PR TITLE
Fix metrics in Horizontal Pod Autoscaler

### DIFF
--- a/overlays/development/jitsi-base/jvb-hpa-patch.yaml
+++ b/overlays/development/jitsi-base/jvb-hpa-patch.yaml
@@ -13,4 +13,4 @@ spec:
           name: container_network_transmit_bytes_per_second
         target:
           type: AverageValue
-          averageValue: 400000
+          averageValue: 400k

--- a/overlays/production/jitsi-base/jvb-hpa-patch.yaml
+++ b/overlays/production/jitsi-base/jvb-hpa-patch.yaml
@@ -13,4 +13,4 @@ spec:
           name: container_network_transmit_bytes_per_second
         target:
           type: AverageValue
-          averageValue: 100000
+          averageValue: 100k

--- a/secrets.sh
+++ b/secrets.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 secretsfile="$1"
 instance="$2"
 
@@ -6,7 +8,7 @@ get-secret () {
 }
 
 encrypt-secret () {
-    get-secret "$1" | base64
+    get-secret "$1" | base64 -w 0
 }
 
 sed -i 's/JICOFO_COMPONENT_SECRET: .*/JICOFO_COMPONENT_SECRET: '$(encrypt-secret "JICOFO_COMPONENT_SECRET")'/g' base/jitsi/jitsi-secret.yaml


### PR DESCRIPTION
Fixes HPA pod metric averageValue.
Average Value for HPA pod metric as a target is of type quantity / string [1] [2]

[1] https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#quantity-resource-core
[2] https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/
