### PR TITLE
Fixes HPA pod metric averageValue.

### DIFF
--- a/overlays/development/jitsi-base/jvb-hpa-patch.yaml
+++ b/overlays/development/jitsi-base/jvb-hpa-patch.yaml
@@ -13,4 +13,4 @@ spec:
           name: container_network_transmit_bytes_per_second
         target:
           type: AverageValue
-          averageValue: 400000
+          averageValue: 400k

--- a/overlays/production/jitsi-base/jvb-hpa-patch.yaml
+++ b/overlays/production/jitsi-base/jvb-hpa-patch.yaml
@@ -13,4 +13,4 @@ spec:
           name: container_network_transmit_bytes_per_second
         target:
           type: AverageValue
-          averageValue: 100000
+          averageValue: 100k


### PR DESCRIPTION
Fixes HPA pod metric averageValue.
Average Value for HPA pod metric as a target is of type quantity / string [1] [2]

[1] https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#quantity-resource-core
[2] https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/
