### PR TITLE
Removes Sync Pod Name DecoratorController and hook

### DIFF
--- a/base/jitsi-shard/jvb/service-per-pod-decoratorcontroller.yaml
+++ b/base/jitsi-shard/jvb/service-per-pod-decoratorcontroller.yaml
@@ -22,23 +22,4 @@ spec:
     finalize:
       webhook:
         url: http://service-per-pod.metacontroller/finalize-service-per-pod
----
-apiVersion: metacontroller.k8s.io/v1alpha1
-kind: DecoratorController
-metadata:
-  name: pod-name-label
-  namespace: jitsi
-spec:
-  resources:
-  - apiVersion: v1
-    resource: pods
-    labelSelector:
-      matchExpressions:
-      - {key: pod-name, operator: DoesNotExist}
-    annotationSelector:
-      matchExpressions:
-      - {key: pod-name-label, operator: Exists}
-  hooks:
-    sync:
-      webhook:
-        url: http://service-per-pod.metacontroller/sync-pod-name-label
+

--- a/base/ops/metacontroller/service-per-pod-configmap.yaml
+++ b/base/ops/metacontroller/service-per-pod-configmap.yaml
@@ -13,16 +13,6 @@ data:
       // Mark as finalized once we observe all Services are gone.
       finalized: std.length(request.attachments['Service.v1']) == 0
     }
-  sync-pod-name-label.jsonnet: |
-    function(request) {
-      local pod = request.object,
-      local labelKey = pod.metadata.annotations["pod-name-label"],
-
-      // Inject the Pod name as a label with the key requested in the annotation.
-      labels: {
-        [labelKey]: pod.metadata.name
-      }
-    }
   sync-service-per-pod.jsonnet: |
     function(request) {
       local statefulset = request.object,
@@ -46,7 +36,7 @@ data:
             labels: {app: "service-per-pod"}
           },
           spec: {
-          selector: {
+            selector: {
               [labelKey]: statefulset.metadata.name + "-" + index
             },
             type: "NodePort",


### PR DESCRIPTION
`StatefulSets` have pod name labels since Kubernetes v1.9 [1]
Minimum supported version in the project is 1.17.2+
The sync pod-name hook is provided in the example repo [2] for older versions where Sts pod-name-labels
are not set by default

[1] https://github.com/kubernetes/kubernetes/pull/55329
[2] https://github.com/GoogleCloudPlatform/metacontroller/tree/master/examples/service-per-pod